### PR TITLE
Docker Java repo update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # VERSION 1.0
 
 # the base image is a trusted ubuntu build with java 7 (https://index.docker.io/u/dockerfile/java/)
-FROM dockerfile/java
+FROM java:7
 
 # that's me!
 MAINTAINER Adam Warski, adam@warski.org


### PR DESCRIPTION
Fix for: Error: image dockerfile/java:latest not found
With reference to: http://blog.docker.com/2015/03/updates-available-to-popular-repos-update-your-images/
You should also update your blog: http://www.warski.org/blog/2014/05/spray-server-docker-container/
